### PR TITLE
Implement getArtwork to get the path to the artwork as  PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ spotify.setVolume(42, function() {
     });
 });
 ```
+
+### getArtwork(callback)
+
+Returns the file path to the current artwork as PNG
+
+```javascript
+var spotify = require('spotify-node-applescript');
+
+spotify.getArtwork(function(err, artworkPath) {
+    console.log('Current artwork is at %s', artworkPath);
+});
+```

--- a/lib/scripts/get_artwork.applescript
+++ b/lib/scripts/get_artwork.applescript
@@ -1,0 +1,31 @@
+tell application "Spotify"
+  set currentArtwork to current track's artwork
+  set savePath to POSIX path of (path to temporary items from user domain as string) & current track's id
+  set tiffPath to (savePath & ".tiff")
+  set pngPath to (savePath & ".png")
+end tell
+
+-- don't do the image events dance when the file already exists
+tell application "Finder"
+  if exists pngPath as POSIX file then
+    return pngPath
+  end if
+end tell
+
+tell application "System Events"
+  set fileRef to (open for access tiffPath with write permission)
+  write currentArtwork to fileRef
+  close access fileRef
+
+  tell application "Image Events"
+    launch
+    set theImage to open tiffPath
+    save theImage as PNG in pngPath
+    quit
+  end tell
+
+  delete file tiffPath
+  quit
+end tell
+
+return pngPath

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -144,3 +144,7 @@ exports.jumpTo = function(position, callback){
         return script.replace('{{position}}', position);
     });
 };
+
+exports.getArtwork = function(callback){
+    return applescript.execFile(__dirname + '/scripts/get_artwork.applescript', callback);
+};

--- a/test/test.js
+++ b/test/test.js
@@ -152,4 +152,14 @@ describe('Spotify Controller', function(){
             });
         }, 1100);
     });
+
+    it('should return the path to the PNG of the current artwork', function(done){
+        spotify.getArtwork(function(err, path){
+            if (err) throw err;
+
+            var fileName = path.split('/').splice(-1)[0];
+            expect(fileName).to.equal('spotify:track:3AhXZa8sUQht0UEdBJgpGc.png');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This implements a getArtwork method that gets the current artwork as
PNG (from the actual TIFF Data that spotify returns). The conversion to
PNG happens because it's more compatible with current browsers and everything.

Example:

``` javascript
var spotify = require('spotify-node-applescript');

spotify.getArtwork(function(err, artworkPath) {
    console.log('Current artwork is at %s', artworkPath);
});
```

Please note: The used applescript takes some time (0.5s to 1.5s on different
machines), so don't run the script too often (_not_ every second) or you
will run into strange errors. Especially don't run them in parallel.

Also the apple script is seperated into an external file, which makes it easier
to maintain IMHO.
