### PR TITLE
Implement isRunning to check whether Spotify is running or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ spotify.setVolume(42, function() {
     });
 });
 ```
+
+### isRunning(callback)
+
+Check if Spotify is running.
+
+```javascript
+var spotify = require('spotify-node-applescript');
+
+spotify.isRunning(function(err, isRunning){
+    console.log(isRunning); // true
+});
+```

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -61,6 +61,13 @@ var scripts = {
     ],
     jumpTo : [
         'tell application "Spotify" to set player position to {{position}}'
+    ],
+
+    isRunning: [
+        'tell application "System Events"',
+        'set ProcessList to name of every process',
+        'return "Spotify" is in ProcessList',
+        'end tell'
     ]
 };
 
@@ -85,6 +92,16 @@ var createJSONResponseHandler = function(callback){
             return callback(error);
         }
     };
+};
+
+exports.isRunning = function(callback) {
+    execScript('isRunning', function(error, response) {
+      if (!error) {
+          return callback(null, response === 'true' ? true : false);
+      } else {
+          return callback(error);
+      }
+    });
 };
 
 exports.open = function(uri, callback){

--- a/test/test.js
+++ b/test/test.js
@@ -152,4 +152,12 @@ describe('Spotify Controller', function(){
             });
         }, 1100);
     });
+
+    it('should return true when spotify is running', function(done) {
+        spotify.isRunning(function(error, isRunning) {
+            expect(error).to.be.null;
+            expect(isRunning).to.be.true;
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This commit adds a `isRunning` method, that checks via AppleScript if
the Spotify application is running or not.

`isRunning` takes a callback as argument. The callback gets passed two
arguments: `error` and `response`. `error` is a possible error bubbling up from
node-applescript.

`response` is a boolean, indicating whether Spotify is running (true) or not
(false).

The included test assumes that Spotify is running (as does the whole test
suite) and expects `isRunning` to return `true`. I did not bother to include the
negative version of the test, since that would mean changing a lot of the test
suite (including quitting and restarting spotify). But the method has been
tested manually and works as expected.
