### PR TITLE
Escape quotes when getting track information

### DIFF
--- a/lib/scripts/get_track.applescript
+++ b/lib/scripts/get_track.applescript
@@ -1,0 +1,25 @@
+on escape_quotes(string_to_escape)
+  set AppleScript's text item delimiters to the "\""
+  set the item_list to every text item of string_to_escape
+  set AppleScript's text item delimiters to the "\\\""
+  set string_to_escape to the item_list as string
+  set AppleScript's text item delimiters to ""
+  return string_to_escape
+end escape_quotes
+
+tell application "Spotify"
+  set ctrack to "{"
+  set ctrack to ctrack & "\"artist\": \"" & my escape_quotes(current track's artist) & "\""
+  set ctrack to ctrack & ",\"album\": \"" & my escape_quotes(current track's album) & "\""
+  set ctrack to ctrack & ",\"disc_number\": " & current track's disc number
+  set ctrack to ctrack & ",\"duration\": " & current track's duration
+  set ctrack to ctrack & ",\"played_count\": " & current track's played count
+  set ctrack to ctrack & ",\"track_number\": " & current track's track number
+  set ctrack to ctrack & ",\"starred\": " & current track's starred
+  set ctrack to ctrack & ",\"popularity\": " & current track's popularity
+  set ctrack to ctrack & ",\"id\": \"" & current track's id & "\""
+  set ctrack to ctrack & ",\"name\": \"" & my escape_quotes(current track's name) & "\""
+  set ctrack to ctrack & ",\"album_artist\": \"" & my escape_quotes(current track's album artist) & "\""
+  set ctrack to ctrack & ",\"spotify_url\": \"" & current track's spotify url & "\""
+  set ctrack to ctrack & "}"
+end tell

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -3,25 +3,6 @@ var exec = require('child_process').exec,
 
 // apple scripts
 var scripts = {
-    track : [
-        'tell application "Spotify"',
-        'set ctrack to "{"',
-        'set ctrack to ctrack & "\\"artist\\": \\"" & current track\'s artist & "\\""',
-        'set ctrack to ctrack & ",\\"album\\": \\"" & current track\'s album & "\\""',
-        'set ctrack to ctrack & ",\\"disc_number\\": " & current track\'s disc number',
-        'set ctrack to ctrack & ",\\"duration\\": " & current track\'s duration',
-        'set ctrack to ctrack & ",\\"played_count\\": " & current track\'s played count',
-        'set ctrack to ctrack & ",\\"track_number\\": " & current track\'s track number',
-        'set ctrack to ctrack & ",\\"starred\\": " & current track\'s starred',
-        'set ctrack to ctrack & ",\\"popularity\\": " & current track\'s popularity',
-        'set ctrack to ctrack & ",\\"id\\": \\"" & current track\'s id & "\\""',
-        'set ctrack to ctrack & ",\\"name\\": \\"" & current track\'s name & "\\""',
-        'set ctrack to ctrack & ",\\"album_artist\\": \\"" & current track\'s album artist & "\\""',
-        'set ctrack to ctrack & ",\\"spotify_url\\": \\"" & current track\'s spotify url & "\\""',
-        'set ctrack to ctrack & "}"',
-        'return ctrack',
-        'end tell'
-    ],
     state: [
         'tell application "Spotify"',
         'set cstate to "{"',
@@ -132,7 +113,10 @@ exports.setVolume = function(volume, callback){
 };
 
 exports.getTrack = function(callback){
-    return execScript('track', createJSONResponseHandler(callback));
+    return applescript.execFile(
+        __dirname + '/scripts/get_track.applescript',
+        createJSONResponseHandler(callback)
+    );
 };
 
 exports.getState = function(callback){

--- a/test/test.js
+++ b/test/test.js
@@ -132,9 +132,9 @@ describe('Spotify Controller', function(){
 //	});
 
     it('play track', function(done){
-        spotify.playTrack('spotify:track:4n1ZGm3TxYmoYe1YR8cMus', function(){
+        spotify.playTrack('spotify:track:4EZz8Byhbjk0tOKFJlCgPB', function(){
             spotify.getTrack(function(error, track){
-                expect(track.name).to.equal('Desolation Row');
+                expect(track.name).to.equal('Never Gonna Give You Up - 7" Vocal Mix');
                 done();
             });
         });


### PR DESCRIPTION
If you have a song title that includes quotes the old version produced
a parse error. For example for "spotify:track:4EZz8Byhbjk0tOKFJlCgPB" you'll run
into this, because it includes 7" in the album title.

With this commit all the quotes in the values getting properly escaped.

This also extracts the get_track script to a seperate file as it makes
maintaining easier.
