### PR TITLE
Added Mute and Unmute

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ spotify.setVolume(42, function() {
 });
 ```
 
+### mute(callback)
+
+Reduces audio to 0, saving the previous volume.
+
+### unmute(callback)
+
+Returns audio to original volume.
+
 ### isRunning(callback)
 
 Check if Spotify is running.

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec,
-    applescript = require('applescript');
+    applescript = require('applescript'),
+    savedVolume = null;
 
 // apple scripts
 var scripts = {
@@ -116,17 +117,33 @@ exports.previous = function(callback){
 };
 
 exports.volumeUp = function(callback){
+    savedVolume = null;
     return execScript('volumeUp', callback);
 };
 
 exports.volumeDown = function(callback){
+    savedVolume = null;
     return execScript('volumeDown', callback);
 };
 
 exports.setVolume = function(volume, callback){
+    if(volume !== 0) savedVolume = null;
     execScript('setVolume', callback, function(script){
         return script.replace('{{volume}}', volume);
     });
+};
+
+exports.mute = function(callback){
+    execScript('state', createJSONResponseHandler(function(err, state) {
+        savedVolume = state.volume;
+        exports.setVolume(0, callback);
+    }));
+};
+
+exports.unmute = function(callback){
+    if(savedVolume !== null) {
+        exports.setVolume(savedVolume, callback);
+    }
 };
 
 exports.getTrack = function(callback){


### PR DESCRIPTION
Pretty simple functionality - unmute only works when a mute has been run immediately before, and works by just using a simple variable to save the original volume value.

For example: 

```
    spotify.mute(function() {}); // will set the volume to 0
    spotify.unmute(function() {}); // returns audio to where it was

    spotify.mute(function() {}); // mutes
    spotify.setVolume(50, function() {});
    spotify.unmute(function() {}); // will have no effect.
```
