### PR TITLE
Do not create TIFF from artwork if it already exists

### DIFF
--- a/lib/scripts/get_artwork.applescript
+++ b/lib/scripts/get_artwork.applescript
@@ -7,6 +7,10 @@ on replace_chars(this_text, search_string, replacement_string)
   return this_text
 end replace_chars
 
+on file_exists(filePath)
+  tell application "Finder" to return exists filePath as POSIX file
+end file_exists
+
 tell application "Spotify"
   set currentArtwork to current track's artwork
   set savePath to POSIX path of (path to temporary items from user domain as string) & my replace_chars(current track's id,":","_")
@@ -15,16 +19,14 @@ tell application "Spotify"
 end tell
 
 -- don't do the image events dance when the file already exists
-tell application "Finder"
-  if exists pngPath as POSIX file then
-    return pngPath
-  end if
-end tell
+if my file_exists(pngPath) then return pngPath
 
 tell application "System Events"
-  set fileRef to (open for access tiffPath with write permission)
-  write currentArtwork to fileRef
-  close access fileRef
+  if not (my file_exists(tiffPath)) then
+    set fileRef to (open for access tiffPath with write permission)
+    write currentArtwork to fileRef
+    close access fileRef
+  end
 
   tell application "Image Events"
     launch


### PR DESCRIPTION
This prevents the creation of the artwork TIFF in get_artwork if the TIFF
already exists.
