### PR TITLE
Refactor isRunning

### DIFF
--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -43,12 +43,8 @@ var scripts = {
     jumpTo : [
         'tell application "Spotify" to set player position to {{position}}'
     ],
-
     isRunning: [
-        'tell application "System Events"',
-        'set ProcessList to name of every process',
-        'return "Spotify" is in ProcessList',
-        'end tell'
+        'get running of application "Spotify"'
     ]
 };
 


### PR DESCRIPTION
After spending more time with AppleScript I found a lot nicer method of determining
whether Spotify is running or not.

This shrinks `isRunning` down to one, easy-to-understand line, using `running`
attribute of the application Spotify. Apparently every application has a
`running` attribute, which I didn't know about before.
