### PR TITLE
Fix get state for locales that have commas as decimal delimiters

### DIFF
--- a/lib/scripts/get_state.applescript
+++ b/lib/scripts/get_state.applescript
@@ -1,21 +1,8 @@
-on replace_chars(this_text, search_string, replacement_string)
-  set AppleScript's text item delimiters to the search_string
-  set the item_list to every text item of this_text
-  set AppleScript's text item delimiters to the replacement_string
-  set this_text to the item_list as string
-  set AppleScript's text item delimiters to ""
-  return this_text
-end replace_chars
-
 tell application "Spotify"
-  -- force string coercion and locale format
-  set position to "" & player position
-
   set cstate to "{"
   set cstate to cstate & "\"track_id\": \"" & current track's id & "\""
   set cstate to cstate & ",\"volume\": " & sound volume
-  -- replace , with . when locale has , as decimal delimiter
-  set cstate to cstate & ",\"position\": " & my replace_chars(position, ",", ".")
+  set cstate to cstate & ",\"position\": " & (player position as integer)
   set cstate to cstate & ",\"state\": \"" & player state & "\""
   set cstate to cstate & "}"
 

--- a/test/test.js
+++ b/test/test.js
@@ -80,7 +80,7 @@ describe('Spotify Controller', function(){
         setTimeout(function(){
             spotify.jumpTo(15, function(){
                 spotify.getState(function(err, state){
-                    expect(Math.floor(state.position)).to.equal(15);
+                    expect(state.position).to.equal(15);
                     done();
                 });
             });


### PR DESCRIPTION
When your current set locale uses "," as decimal delimiter, AppleScript
will automatically use this when you convert the number to a string. This
will break the JSON parsing for the callback, as "," is invalid when not
in quotes.
