### PR TITLE
Revert "Update get_state.applescript"

### DIFF
--- a/lib/scripts/get_state.applescript
+++ b/lib/scripts/get_state.applescript
@@ -2,7 +2,7 @@ tell application "Spotify"
   set cstate to "{"
   set cstate to cstate & "\"track_id\": \"" & current track's id & "\""
   set cstate to cstate & ",\"volume\": " & sound volume
-  set cstate to cstate & ",\"position\": " & (player position)
+  set cstate to cstate & ",\"position\": " & (player position as integer)
   set cstate to cstate & ",\"state\": \"" & player state & "\""
   set cstate to cstate & "}"
 


### PR DESCRIPTION
This change breaks the tests. It gives back position like '1,234' (notice the comma) on my computer. JSON.parse() throws an error on result from applescript. Probably dependent on system language.