### PR TITLE
Check result for undefined and prevent JSON Parse

### DIFF
--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -86,7 +86,7 @@ var execScript = function(scriptName, params, callback){
 var createJSONResponseHandler = function(callback, flag){
     if (!callback) return null;
     return function(error, result){
-        if (!error){
+        if (!error && result !== undefined){
             try {
                 result = JSON.parse(result);
             } catch(e){


### PR DESCRIPTION
I was running into issues where `getState` script would result in `undefined` which would cause the `JSON.parse(result)` to throw and error.